### PR TITLE
V2016.2

### DIFF
--- a/site.conf
+++ b/site.conf
@@ -1,17 +1,12 @@
-
 {
   hostname_prefix = 'ffkbuk-',
-
   site_name = 'Freifunk KBU Hood Koeln',
-
-  -- Shorthand of the community.
   site_code = 'ffkbuk',
-   opkg = {
-   openwrt = 'http://openwrt.draic.info/%n/%v/%S/packages',
-   extra = {
-	modules = '',
+  
+	opkg = {
+		openwrt = 'http://openwrt.draic.info/%n/%v/%S/packages',
 	},
-    },
+
   -- Prefixes used within the mesh. Both are required.
   prefix4 = '10.158.0.0/18',
   prefix6 = 'fdd3:5d16:b5dd:01fc::/64',
@@ -19,44 +14,49 @@
   -- Timezone of your community.
   -- See http://wiki.openwrt.org/doc/uci/system#time_zones
   timezone = 'CET-1CEST,M3.5.0,M10.5.0/3',
-
-  -- Needs more, direct ipv6 ntp servers
+  
+  -- List of NTP servers in your community.
   -- Must be reachable using IPv6!
-
-  ntp_servers = {'2.pool.ntp.org'},
+  ntp_servers = {
+    '2.pool.ntp.org',
+    '0.openwrt.pool.ntp.org',
+    '1.openwrt.pool.ntp.org',
+    '2.openwrt.pool.ntp.org',
+    '3.openwrt.pool.ntp.org',
+  },
 
   -- Wireless regulatory domain of your community.
   regdom = 'DE',
 
   -- Wireless configuration for 2.4 GHz interfaces.
-   wifi24 = {
-        channel = 1,
-	ap = {
-	    	ssid = 'kbu.freifunk.net',
-             },
- 	ibss = {
-	        ssid = '02:d2:22:01:fc:22',  -- ESSID used for mesh
-    		bssid = '02:d2:22:01:fc:22', -- BSSID used for mesh
-   		mcast_rate = 12000,
-               },
-	    },
-
-  -- Wireless configuration for 5 GHz interfaces.
-  -- This should be equal to the 2.4 GHz variant, except
-  -- for channel and htmode.
-  wifi5 = {
-    channel = 44,
-	ap = {
-		    ssid = 'kbu.freifunk.net',
-    	     },
-      ibss = {
-		    ssid = '02:d2:22:01:fc:23',
-		    bssid = '02:d2:22:01:fc:23',
-		    mcast_rate = 12000,
-	  },
+  wifi24 = {
+    -- Wireless channel.
+    channel = 1,
+    ap = {
+            -- ESSID used for client network.
+            ssid = 'kbu.freifunk.net',
+        },
+        ibss ={
+            ssid = '02:d2:22:01:fc:22',  -- ESSID used for mesh
+            bssid = '02:d2:22:01:fc:22', -- BSSID used for mesh
+            -- Bitrate used for multicast/broadcast packets.
+            mcast_rate = 12000,
+        },
   },
 
-
+  -- Wireless configuration for 5 GHz interfaces.
+  -- This should be equal to the 2.4 GHz variant, except for channel.
+  wifi5 = {
+        channel = 44,
+        ap = {
+            ssid = 'kbu.freifunk.net',
+        },
+        ibss = {
+        ssid = '02:d2:22:01:fc:23',  -- ESSID used for mesh
+        bssid = '02:d2:22:01:fc:23', -- BSSID used for mesh
+        mcast_rate = 12000,
+        },
+  },
   -- The next node feature allows clients to always reach the node it is
   -- connected to using a known IP address.
   next_node = {
@@ -71,75 +71,57 @@
   -- Refer to http://fastd.readthedocs.org/en/latest/ to better understand
   -- what these options do.
   fastd_mesh_vpn = {
+    -- List of crypto-methods to use.
     methods = {'salsa2012+umac'},
-    enabled = true,
     configurable = true,
-    bandwidth_limit = {
-   			 enabled = false,
- 			   ingress = 3000,
- 			   egress = 384,
-    		    },
+    enabled = true,
     mtu = 1312,
+    bandwidth_limit = {
+                enabled = false,
+                ingress = 3000,
+                egress = 384,
+        },
     groups = {
       backbone = {
-        limit = 1,
+          -- Limit number of connected peers to reduce bandwidth.
+        limit = 2,
         peers = {
           peer1 = {
-            key = 'ae120edbbd07dce57c2ed6ebefd112886a1416322e7a98352866eed1e0d633cc',
-            remotes = {'"vpn1.kbu.freifunk.net" port 10010'
-                      },
+              key = 'ae120edbbd07dce57c2ed6ebefd112886a1416322e7a98352866eed1e0d633cc',
+              remotes = {'"vpn1.kbu.freifunk.net" port 10010'},
           },
           peer2 = {
-            key = '3e01de6c771cf5a50375de4f05e51f7d9251b5659ab9fb54040bf41df411ae46',
-            remotes = {'"vpn2.kbu.freifunk.net" port 10010'
-                      },
+              key = '3e01de6c771cf5a50375de4f05e51f7d9251b5659ab9fb54040bf41df411ae46',
+              remotes = {'"vpn2.kbu.freifunk.net" port 10010'},
           },
           peer3 = {
-            key = 'c46d7e141b60be6e57ada3087f1b25beb0bfb51e6b42d1c7f02a067d89c13a1a',
-            remotes = {'"vpn3.kbu.freifunk.net" port 10010'
-                      },
+              key = 'c46d7e141b60be6e57ada3087f1b25beb0bfb51e6b42d1c7f02a067d89c13a1a',
+              remotes = {'"vpn3.kbu.freifunk.net" port 10010'},
           },
           peer4 = {
-            key = 'f4aff2422921822102ed6e67807b0b5db334f04e071356d30fe6c927b8bb9839',
-            remotes = {'"vpn4.kbu.freifunk.net" port 10010'
-                      },
+              key = 'f4aff2422921822102ed6e67807b0b5db334f04e071356d30fe6c927b8bb9839',
+              remotes = {'"vpn4.kbu.freifunk.net" port 10010'},
           },
           peer5 = {
-            key = 'a6df938cfde83b437346c91e2e548516a25321fb72820f9f757d9479240e26af',
-            remotes = {'"vpn5.kbu.freifunk.net" port 10009'
-                      },
+              key = 'a6df938cfde83b437346c91e2e548516a25321fb72820f9f757d9479240e26af',
+              remotes = {'"vpn5.kbu.freifunk.net" port 10009'},
           },
           peer6 = {
-            key = 'f125456692a9804885ebc33375d0de6ac934b317fc45682849019704d8ee830d',
-            remotes = {'"vpn6.kbu.freifunk.net" port 10009'
-                      },
+              key = 'f125456692a9804885ebc33375d0de6ac934b317fc45682849019704d8ee830d',
+              remotes = {'"vpn6.kbu.freifunk.net" port 10009'},
           },
           peer7 = {
-            key = '389e8ebdf7a7329279b2eb006bd3cf92691eb26f3518e1c596b8634c9f0a3002',
-            remotes = {'"vpn7.kbu.freifunk.net" port 10009'
-                      },
+              key = '389e8ebdf7a7329279b2eb006bd3cf92691eb26f3518e1c596b8634c9f0a3002',
+              remotes = {'"vpn7.kbu.freifunk.net" port 10009'},
           },
           peer8 = {
-            key = 'f9dddb5a3f184fc3b10a6b16205c2392be4d11ae0af4901cb901f7f0d103333a',
-            remotes = {'"vpn8.kbu.freifunk.net" port 10009'
-                      },
+              key = 'f9dddb5a3f184fc3b10a6b16205c2392be4d11ae0af4901cb901f7f0d103333a',
+              remotes = {'"vpn8.kbu.freifunk.net" port 10009'},
           },
         },
-        -- Optional: nested peer groups
-        -- groups = {
-        --   backbone_sub = {
-        --     ...
-        --   },
-        --   ...
-        -- },
       },
-      -- Optional: additional peer groups, possibly with other limits
-      -- backbone2 = {
-      --   ...
-      -- },
     },
   },
-
   autoupdater = {
     branch = 'noupdate',
     branches = {
@@ -167,9 +149,8 @@
   --   },
   -- },
 
-  -- Bandwidth limiting
- 
-  setup_mode = {
-  skip = true,
-  },
+  -- Skip setup mode (config mode) on first boot
+    setup_mode = {
+        skip = false,
+    },
 }

--- a/site.mk
+++ b/site.mk
@@ -6,7 +6,6 @@
 
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-15 \
-	gluon-alfred \
 	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-autoupdater \

--- a/site.mk
+++ b/site.mk
@@ -193,3 +193,5 @@ GLUON_LANGS ?= en de
 
 # Region settings for ARCHERC7
 GLUON_REGION ?= eu
+
+GLUON_ATH10K_MESH = ibss

--- a/site.mk
+++ b/site.mk
@@ -7,7 +7,7 @@
 GLUON_SITE_PACKAGES := \
 	gluon-mesh-batman-adv-15 \
 	gluon-alfred \
-	gluon-announced \
+	gluon-respondd \
 	gluon-autoupdater \
 	gluon-config-mode-autoupdater \
 	gluon-config-mode-contact-info \
@@ -17,6 +17,8 @@ GLUON_SITE_PACKAGES := \
 	gluon-config-mode-mesh-vpn \
 	gluon-ebtables-filter-multicast \
 	gluon-ebtables-filter-ra-dhcp \
+	gluon-neighbour-info \
+        gluon-luci-private-wifi \
 	gluon-luci-admin \
 	gluon-luci-autoupdater \
 	gluon-luci-portconfig \
@@ -30,14 +32,149 @@ GLUON_SITE_PACKAGES := \
 	iptables \
 	iwinfo
 
+# basic support for USB stack
+USB_PACKAGES_BASIC := \
+	kmod-usb-core \
+	kmod-usb2
+
+# storage support for USB devices
+USB_PACKAGES_STORAGE := \
+	block-mount \
+	blkid \
+	kmod-fs-ext4 \
+	kmod-fs-vfat \
+	kmod-usb-storage \
+	kmod-usb-storage-extras \
+	kmod-nls-cp1250 \
+	kmod-nls-cp1251 \
+	kmod-nls-cp437 \
+	kmod-nls-cp775 \
+	kmod-nls-cp850 \
+	kmod-nls-cp852 \
+	kmod-nls-cp866 \
+	kmod-nls-iso8859-1 \
+	kmod-nls-iso8859-13 \
+	kmod-nls-iso8859-15 \
+	kmod-nls-iso8859-2 \
+	kmod-nls-koi8r \
+	kmod-nls-utf8 \
+	swap-utils
+
+# network support for USB devices
+USB_PACKAGES_NET := \
+	kmod-mii \
+	kmod-nls-base \
+	kmod-usb-net \
+	kmod-usb-net-asix \
+	kmod-usb-net-asix-ax88179 \
+	kmod-usb-net-cdc-eem \
+	kmod-usb-net-cdc-ether \
+	kmod-usb-net-cdc-mbim \
+	kmod-usb-net-cdc-ncm \
+	kmod-usb-net-cdc-subset \
+	kmod-usb-net-dm9601-ether \
+	kmod-usb-net-hso \
+	kmod-usb-net-huawei-cdc-ncm \
+	kmod-usb-net-ipheth \
+	kmod-usb-net-kalmia \
+	kmod-usb-net-kaweth \
+	kmod-usb-net-mcs7830 \
+	kmod-usb-net-pegasus \
+	kmod-usb-net-qmi-wwan \
+	kmod-usb-net-rndis \
+	kmod-usb-net-sierrawireless \
+	kmod-usb-net-smsc95xx
+# broken
+#	kmod-usb-net-rtl8150 \
+#	kmod-usb-net-rtl8152 \
+# network support for PCI devices
+PCI_PACKAGES_NET := \
+	kmod-3c59x \
+	kmod-e100 \
+	kmod-e1000 \
+	kmod-e1000e \
+	kmod-forcedeth \
+	kmod-natsemi \
+	kmod-ne2k-pci \
+	kmod-pcnet32 \
+	kmod-r8169 \
+	kmod-sis900 \
+	kmod-sky2 \
+	kmod-tg3 \
+	kmod-tulip \
+	kmod-via-rhine
+# broken
+#	kmod-ixgbe \
+#	kmod-r8139too \
+# additional packages
+TOOLS_PACKAGES := \
+	iperf \
+	socat \
+	tcpdump \
+	usbutils \
+	vnstat
+# broken
+#	pciutils \
+#
+# $(GLUON_TARGET) specific settings:
+#
+
+# x86-generic
+ifeq ($(GLUON_TARGET),x86-generic)
+# support the usb stack on x86 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES)
+endif
+
+# x86-64
+ifeq ($(GLUON_TARGET),x86-64)
+# support the usb stack on x86-64 devices
+# and add a few common USB and PCI NICs
+GLUON_SITE_PACKAGES += \
+	kmod-usb-hid \
+	kmod-hid-generic \
+	$(USB_PACKAGES_BASIC) \
+	$(USB_PACKAGES_STORAGE) \
+	$(USB_PACKAGES_NET) \
+	$(PCI_PACKAGES_NET) \
+	$(TOOLS_PACKAGES)
+endif
+
+ifeq ($(GLUON_TARGET),x86-kvm_guest)
+GLUON_SITE_PACKAGES += \
+	$(TOOLS_PACKAGES)
+endif
+
+# ar71xx-generic
+GLUON_TLWR842_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR1043_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWR2543_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_TLWDR4300_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WNDR3700_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WRT160NL_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_ARCHERC7_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_GLINET_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPG450H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+GLUON_WZRHPAG300H_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
+# mpc85xx-generic
+GLUON_TLWDR4900_SITE_PACKAGES := $(USB_PACKAGES_BASIC) $(TOOLS_PACKAGES) $(USB_PACKAGES_STORAGE)
+
 ##	DEFAULT_GLUON_RELEASE
 #		version string to use for images
 #		gluon relies on
 #			opkg compare-versions "$1" '>>' "$2"
 #		to decide if a version is newer or not.
 
-DEFAULT_GLUON_RELEASE := 0.6+compat15exp$(shell date '+%Y%m%d')
-
+# Firmware name pattern
+DEFAULT_GLUON_RELEASE := 2016.2-exp$(shell date '+%Y%m%d')
 
 ##	GLUON_RELEASE
 #		call make with custom GLUON_RELEASE flag, to use your own release version scheme.
@@ -54,3 +191,6 @@ GLUON_PRIORITY ?= 0
 
 # Languages to include
 GLUON_LANGS ?= en de
+
+# Region settings for ARCHERC7
+GLUON_REGION ?= eu


### PR DESCRIPTION
(+) Gluon 2016.2.x Anpassungen
(+) setup on first boot true

GLUON_SITE_PACKAGES 
(-)	gluon-alfred 
(-)	gluon-announced 
(+)	gluon-respondd 
(+)	gluon-luci-private-wifi 
(+)	gluon-neighbour-info 

(+) Targets mit ausreichend Speicher bekommen Zusatzpakete vorinstalliert.